### PR TITLE
feat: shim and unshim all hooks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
             . venv/bin/activate
             flake8 --statistics
             coverage run -m pytest -v
-            coveralls debug
+            coveralls
       - store_test_results:
           path: test-reports
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
             . venv/bin/activate
             flake8 --statistics
             pytest -v --cov --junitxml=test-reports/junit.xml
+            coveralls
       - store_test_results:
           path: test-reports
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           command: |
             . venv/bin/activate
             flake8 --statistics
-            coverage run -m pytest -v --cov
+            coverage run -m pytest -v
             coveralls debug
       - store_test_results:
           path: test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,12 +35,13 @@ jobs:
           command: |
             . venv/bin/activate
             flake8 --statistics
-            pytest -v --cov --junitxml=test-reports/junit.xml
+            pytest -v --cov
+            coverage xml
             coveralls
       - store_test_results:
-          path: test-reports
+          path: coverage.xml
       - store_artifacts:
-          path: test-reports
+          path: coverage.xml
   deploy:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           command: |
             . venv/bin/activate
             flake8 --statistics
-            coverage run -m pytest -v
+            pytest -v --cov --junitxml=test-reports/junit.xml
             coveralls
       - store_test_results:
           path: test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,13 +35,12 @@ jobs:
           command: |
             . venv/bin/activate
             flake8 --statistics
-            pytest -v --cov
-            coverage xml
-            coveralls
+            coverage run -m pytest -v --cov
+            coveralls debug
       - store_test_results:
-          path: coverage.xml
+          path: test-reports
       - store_artifacts:
-          path: coverage.xml
+          path: test-reports
   deploy:
     <<: *defaults
     steps:

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,3 @@
 [run]
 omit = venv/*, tests/*
+include = python_githooks/*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # python-githooks
 
-[![code linting: flake8](https://img.shields.io/badge/lint-flake8-blue.svg)](http://flake8.pycqa.org/)  [![code quality: pytest](https://img.shields.io/badge/test-pytest-yellow.svg)](https://docs.pytest.org/) [![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://lbesson.mit-license.org/)
+[![code linting: flake8](https://img.shields.io/badge/lint-flake8-blue.svg)](http://flake8.pycqa.org/) [![code quality: pytest](https://img.shields.io/badge/test-pytest-yellow.svg)](https://docs.pytest.org/) [![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://lbesson.mit-license.org/)
 [![CircleCI](https://circleci.com/gh/ygpedroso/python-githooks.svg?style=svg)](https://circleci.com/gh/ygpedroso/python-githooks)
 
 > Create git hooks with ease using a simple configuration file in a git project
@@ -13,8 +13,8 @@ pip install python-githooks
 
 ## Usage
 
-1. Create a `.githooks.ini` configuration file(If not provided a dummy configuration file will be created).
-2. Add sections based on `git hooks names`  followed by a `command` property with the shell code you want to run.
+1. Create a `.githooks.ini` configuration file (If not provided a dummy configuration file will be created).
+2. Add sections based on `git hooks names` followed by a `command` property with the shell code you want to run.
 3. Run either `python -m python_githooks` or `githooks` in your virtual environment.
 
 **Configuration file example**:
@@ -43,6 +43,13 @@ command =
 ```
 
 This will not actually physically remove the hook from the git local project, just will make it instantly exit with `0` status code.
+
+## Unuse
+
+1. Running `python -m python_githooks --deactivate` or `githooks --deactivate` will stop shimming git hooks but keep the commands in `.git/hooks`
+2. Run `rm .githooks.ini` to remove the configuration file (optional).
+3. `rm .git/hooks/pre-commit` or any other githook to stop them from executing (optional).
+   e.g. `rm .git/hooks/*`
 
 ## License
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import shutil
 import pytest
 from collections import namedtuple
@@ -10,6 +11,14 @@ __GITHOOKS_CONFIGFILE_PATH__ = os.path.join(__BASE_DIR__, ".githooks.ini")
 __PATHS__ = namedtuple("Paths", ["base", "hooks", "config"])(
     base=__BASE_DIR__, hooks=__GITHOOKS_BASE_DIR__, config=__GITHOOKS_CONFIGFILE_PATH__
 )
+
+
+@pytest.fixture
+def no_sys_args():
+    initial_args = sys.argv
+    sys.argv = initial_args[:1]
+    yield sys.argv
+    sys.argv = initial_args
 
 
 @pytest.fixture

--- a/conftest.py
+++ b/conftest.py
@@ -1,29 +1,33 @@
 import os
 import shutil
 import pytest
+from collections import namedtuple
 from python_githooks.helpers import create_config_file
 
-__BASE_DIR__ = os.path.join(os.environ["PWD"], 'tmp')
-__GITHOOKS_BASE_DIR__ = os.path.join(__BASE_DIR__, '.git/hooks')
-__GITHOOKS_CONFIGFILE_PATH__ = os.path.join(__BASE_DIR__, '.githooks.ini')
+__BASE_DIR__ = os.path.join(os.environ["PWD"], "tmp")
+__GITHOOKS_BASE_DIR__ = os.path.join(__BASE_DIR__, ".git/hooks")
+__GITHOOKS_CONFIGFILE_PATH__ = os.path.join(__BASE_DIR__, ".githooks.ini")
+__PATHS__ = namedtuple("Paths", ["base", "hooks", "config"])(
+    base=__BASE_DIR__, hooks=__GITHOOKS_BASE_DIR__, config=__GITHOOKS_CONFIGFILE_PATH__
+)
 
 
 @pytest.fixture
 def workspace_without_git():
     os.makedirs(__BASE_DIR__)
-    yield __BASE_DIR__
+    yield __PATHS__
     shutil.rmtree(__BASE_DIR__)
 
 
 @pytest.fixture
 def workspace_with_git():
     os.makedirs(__GITHOOKS_BASE_DIR__)
-    yield __BASE_DIR__
+    yield __PATHS__
     shutil.rmtree(__BASE_DIR__)
 
 
 @pytest.fixture
 def workspace_with_config(workspace_with_git):
     create_config_file(__GITHOOKS_CONFIGFILE_PATH__)
-    yield __BASE_DIR__
+    yield __PATHS__
     os.remove(__GITHOOKS_CONFIGFILE_PATH__)

--- a/python_githooks/__main__.py
+++ b/python_githooks/__main__.py
@@ -47,7 +47,8 @@ def main():
         args = parse_args()
         if args.hook:
             execute_git_hook(
-                configfile_path=__GITHOOKS_CONFIGFILE_PATH__, section=args.hook.strip()
+                hook_name=args.hook.strip(),
+                configfile_path=__GITHOOKS_CONFIGFILE_PATH__,
             )
             return
         if args.deactivate:

--- a/python_githooks/__main__.py
+++ b/python_githooks/__main__.py
@@ -1,28 +1,82 @@
 import os
 import sys
-from .helpers import create_config_file, create_git_hooks, execute_git_hook
+import argparse
+
+from .constants import AVAILABLE_HOOKS, CONFIG_FILENAME, GITHOOKS_RELATIVE_DIR
+from .helpers import (
+    create_config_file,
+    create_git_hooks,
+    delete_git_hooks,
+    execute_git_hook,
+)
 
 __BASE_DIR__ = os.environ["PWD"]
-__GITHOOKS_BASE_DIR__ = os.path.join(__BASE_DIR__, '.git/hooks')
-__GITHOOKS_CONFIGFILE_PATH__ = os.path.join(__BASE_DIR__, '.githooks.ini')
+__GITHOOKS_BASE_DIR__ = os.path.join(__BASE_DIR__, GITHOOKS_RELATIVE_DIR)
+__GITHOOKS_CONFIGFILE_PATH__ = os.path.join(__BASE_DIR__, CONFIG_FILENAME)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Shim git hooks for easier configuration"
+    )
+    parser.add_argument(
+        "hook",
+        metavar="git.hook",
+        type=str,
+        nargs="?",
+        choices=AVAILABLE_HOOKS,
+        help="name of git hook to execute",
+    )
+    parser.add_argument(
+        "--activate",
+        default=True,
+        action="store_true",
+        help="activates python_githooks shimming",
+    )
+    parser.add_argument(
+        "--deactivate",
+        default=False,
+        action="store_true",
+        help="deactivates python_githooks shimming",
+    )
+    return parser.parse_args(sys.argv[1:])
 
 
 def main():
     if os.path.isdir(__GITHOOKS_BASE_DIR__):
-        if sys.argv[1:]:
-            execute_git_hook(section=sys.argv[1].strip(), configfile_path=__GITHOOKS_CONFIGFILE_PATH__)
-        else:
+        args = parse_args()
+        if args.hook:
+            execute_git_hook(
+                configfile_path=__GITHOOKS_CONFIGFILE_PATH__, section=args.hook.strip()
+            )
+            return
+        if args.deactivate:
+            delete_git_hooks(
+                configfile_path=__GITHOOKS_CONFIGFILE_PATH__,
+                githooks_dir=__GITHOOKS_BASE_DIR__,
+            )
+            return
+        if args.activate:
             if not os.path.isfile(__GITHOOKS_CONFIGFILE_PATH__):
+                print("Creating sample configuration")
                 create_config_file(configfile_path=__GITHOOKS_CONFIGFILE_PATH__)
-            create_git_hooks(configfile_path=__GITHOOKS_CONFIGFILE_PATH__, githooks_dir=__GITHOOKS_BASE_DIR__)
+            else:
+                print("Found configuration file")
+
+            print("Installing githooks...\n")
+            create_git_hooks(
+                configfile_path=__GITHOOKS_CONFIGFILE_PATH__,
+                githooks_dir=__GITHOOKS_BASE_DIR__,
+            )
+            return
     else:
-        message = '''
+        message = """
         Sorry, this is not a GIT repository.
         Please, run 'git init' before trying to install the hooks.
-        '''
+        """
         print(message)
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/python_githooks/constants.py
+++ b/python_githooks/constants.py
@@ -25,7 +25,8 @@ GITHOOKS_RELATIVE_DIR = os.path.join(".git", "hooks")
 # Githooks configuration
 CONFIG_FILENAME = ".githooks.ini"
 CONFIG_COMMAND_KEY = "command"
+DEFAULT_COMMANDS = {"pre-commit": "echo Replace this line with your own command"}
 DEFAULT_CONFIGURATION = {
-    **{hook: {CONFIG_COMMAND_KEY: ""} for hook in AVAILABLE_HOOKS},
-    "pre-commit": {CONFIG_COMMAND_KEY: "echo Replace this line with your own command"},
+    hook: {CONFIG_COMMAND_KEY: DEFAULT_COMMANDS.get(hook, "")}
+    for hook in sorted(AVAILABLE_HOOKS)
 }

--- a/python_githooks/constants.py
+++ b/python_githooks/constants.py
@@ -1,0 +1,31 @@
+import os
+
+# Supported git hooks
+AVAILABLE_HOOKS = {
+    "applypatch-msg",
+    "commit-msg",
+    "pre-applypatch",
+    "pre-auto-gc",
+    "pre-commit",
+    "pre-push",
+    "pre-rebase",
+    "pre-receive",
+    "prepare-commit-msg",
+    "post-applypatch",
+    "post-commit",
+    "post-checkout",
+    "post-merge",
+    "post-receive",
+    "post-rewrite",
+    "post-update",
+    "update",
+}
+# Git hooks relative dir
+GITHOOKS_RELATIVE_DIR = os.path.join(".git", "hooks")
+# Githooks configuration
+CONFIG_FILENAME = ".githooks.ini"
+CONFIG_COMMAND_KEY = "command"
+DEFAULT_CONFIGURATION = {
+    **{hook: {CONFIG_COMMAND_KEY: ""} for hook in AVAILABLE_HOOKS},
+    "pre-commit": {CONFIG_COMMAND_KEY: "echo Replace this line with your own command"},
+}

--- a/python_githooks/helpers.py
+++ b/python_githooks/helpers.py
@@ -75,7 +75,7 @@ def _create_git_hook(*, hook_name, config_section, githook_file):
 def create_git_hooks(*, configfile_path, githooks_dir):
     config = _get_config_file(configfile_path)
     if not config:
-        _unable_to_find_config()
+        return _unable_to_find_config()
 
     for section in config.sections():
         _create_git_hook(
@@ -117,7 +117,7 @@ def delete_git_hooks(*, configfile_path, githooks_dir):
     config = _get_config_file(configfile_path)
     try:
         if not config:
-            _unable_to_find_config()
+            return _unable_to_find_config()
 
         for hook in AVAILABLE_HOOKS:
             _delete_git_hook(
@@ -134,12 +134,15 @@ def delete_git_hooks(*, configfile_path, githooks_dir):
         )
 
 
-def execute_git_hook(*, configfile_path, section):
-    print("python-githooks > {}".format(section))
+def execute_git_hook(*, hook_name, configfile_path):
+    action = "python-githooks > {}".format(hook_name)
     config = _get_config_file(configfile_path)
     if not config:
-        _unable_to_find_config()
+        print(action)
+        return _unable_to_find_config()
 
-    if config.has_option(section, CONFIG_COMMAND_KEY):
-        command = config[section][CONFIG_COMMAND_KEY]
-        sys.exit(subprocess.call(command, shell=True))
+    if config.has_option(hook_name, CONFIG_COMMAND_KEY):
+        command = config[hook_name][CONFIG_COMMAND_KEY]
+        if command:
+            print(action)
+            sys.exit(subprocess.call(command, shell=True))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ atomicwrites==1.2.1
 attrs==18.2.0
 configparser==3.5.0
 coverage==4.5.2
+coveralls==1.7.0
 flake8==3.6.0
 mccabe==0.6.1
 more-itertools==4.3.0

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,58 +1,83 @@
 import os
 from configparser import ConfigParser
 from python_githooks.constants import AVAILABLE_HOOKS
-from python_githooks.helpers import create_config_file, create_git_hooks, execute_git_hook
+from python_githooks.helpers import (
+    create_config_file,
+    create_git_hooks,
+    execute_git_hook,
+)
 
 
 def test_config_file_creation(workspace_without_git):
     """create_config_file helper function should create file"""
-    configfile_path = os.path.join(workspace_without_git, '.githooks.ini')
+    configfile_path = os.path.join(workspace_without_git, ".githooks.ini")
     create_config_file(configfile_path=configfile_path)
     assert os.path.isfile(configfile_path)
 
 
 def test_config_file_default_values(workspace_without_git):
     """create_config_file helper function should create file with defaults values"""
-    configfile_path = os.path.join(workspace_without_git, '.githooks.ini')
+    default_pre_commit_command = "echo Replace this line with your own command"
+    configfile_path = os.path.join(workspace_without_git, ".githooks.ini")
     create_config_file(configfile_path=configfile_path)
     config = ConfigParser()
     config.read(configfile_path)
     assert config.sections() == list(AVAILABLE_HOOKS)
-    assert config['pre-commit']['command'] == 'echo Replace this line with your own command'
+    assert config["pre-commit"]["command"] == default_pre_commit_command
 
 
 def test_git_hook_creation(workspace_with_git):
     """create_git_hooks helper function should create hooks files in the git hook folder"""
-    githooks_dir = os.path.join(workspace_with_git, '.git/hooks')
-    assert os.path.isfile(os.path.join(githooks_dir, 'pre-commit')) is False
-    configfile_path = os.path.join(workspace_with_git, '.githooks.ini')
+    githooks_dir = os.path.join(workspace_with_git, ".git/hooks")
+    for hook_name in AVAILABLE_HOOKS:
+        assert os.path.isfile(os.path.join(githooks_dir, hook_name)) is False
+
+    configfile_path = os.path.join(workspace_with_git, ".githooks.ini")
     create_config_file(configfile_path=configfile_path)
     create_git_hooks(configfile_path=configfile_path, githooks_dir=githooks_dir)
-    assert os.path.isfile(os.path.join(githooks_dir, 'pre-commit')) is True
-    with open(os.path.join(githooks_dir, 'pre-commit'), 'r') as f:
-        assert f.read() == 'githooks pre-commit'
+
+    for hook_name in AVAILABLE_HOOKS:
+        assert os.path.isfile(os.path.join(githooks_dir, hook_name)) is True
+        with open(os.path.join(githooks_dir, hook_name), "r") as f:
+            assert f.read() == "githooks {}".format(hook_name)
 
 
 def test_git_hook_creation_permissions(workspace_with_git):
     """create_git_hooks helper function should create hooks files with correct permissions"""
-    githooks_dir = os.path.join(workspace_with_git, '.git/hooks')
-    configfile_path = os.path.join(workspace_with_git, '.githooks.ini')
+    githooks_dir = os.path.join(workspace_with_git, ".git/hooks")
+    configfile_path = os.path.join(workspace_with_git, ".githooks.ini")
     create_config_file(configfile_path=configfile_path)
     create_git_hooks(configfile_path=configfile_path, githooks_dir=githooks_dir)
-    assert os.access(os.path.join(githooks_dir, 'pre-commit'), os.X_OK) is True
+    for hook_name in AVAILABLE_HOOKS:
+        assert os.access(os.path.join(githooks_dir, hook_name), os.X_OK) is True
 
 
 def test_git_hook_creation_exit(mocker, workspace_with_git):
     """create_git_hooks helper function should exit if not valid configuration file is provided"""
-    mocked_sys_exit = mocker.patch('sys.exit')
-    githooks_dir = os.path.join(workspace_with_git, '.git/hooks')
-    create_git_hooks(configfile_path='wrong_config_file.ini', githooks_dir=githooks_dir)
+    mocked_sys_exit = mocker.patch("sys.exit")
+    githooks_dir = os.path.join(workspace_with_git, ".git/hooks")
+    create_git_hooks(configfile_path="wrong_config_file.ini", githooks_dir=githooks_dir)
+    mocked_sys_exit.assert_called_once_with(1)
+
+
+def test_git_hook_execution_no_config(mocker):
+    """execute_git_hook helper function should exit with command successfully executed"""
+    mocked_sys_exit = mocker.patch("sys.exit")
+    execute_git_hook(hook_name="pre-commit", configfile_path="wrong_config_file.ini")
     mocked_sys_exit.assert_called_once_with(1)
 
 
 def test_git_hook_execution_exit(mocker, workspace_with_config):
     """execute_git_hook helper function should exit with command successfully executed"""
-    mocked_sys_exit = mocker.patch('sys.exit')
-    configfile_path = os.path.join(workspace_with_config, '.githooks.ini')
-    execute_git_hook(hook_name='pre-commit', configfile_path=configfile_path)
+    mocked_sys_exit = mocker.patch("sys.exit")
+    configfile_path = os.path.join(workspace_with_config, ".githooks.ini")
+    execute_git_hook(hook_name="pre-commit", configfile_path=configfile_path)
     mocked_sys_exit.assert_called_once_with(0)
+
+
+def test_git_hook_execution_no_exit(mocker, workspace_with_config):
+    """execute_git_hook helper function should exit with command successfully executed"""
+    mocked_sys_exit = mocker.patch("sys.exit")
+    configfile_path = os.path.join(workspace_with_config, ".githooks.ini")
+    execute_git_hook(hook_name="no-commit", configfile_path=configfile_path)
+    mocked_sys_exit.assert_not_called()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,6 @@
 import os
 from configparser import ConfigParser
+from python_githooks.constants import AVAILABLE_HOOKS
 from python_githooks.helpers import create_config_file, create_git_hooks, execute_git_hook
 
 
@@ -16,8 +17,8 @@ def test_config_file_default_values(workspace_without_git):
     create_config_file(configfile_path=configfile_path)
     config = ConfigParser()
     config.read(configfile_path)
-    assert config.sections() == ['pre-commit']
-    assert config['pre-commit']['command'] == 'echo Pre commit hook installed. Replace this line with your own command'
+    assert config.sections() == list(AVAILABLE_HOOKS)
+    assert config['pre-commit']['command'] == 'echo Replace this line with your own command'
 
 
 def test_git_hook_creation(workspace_with_git):
@@ -26,7 +27,7 @@ def test_git_hook_creation(workspace_with_git):
     assert os.path.isfile(os.path.join(githooks_dir, 'pre-commit')) is False
     configfile_path = os.path.join(workspace_with_git, '.githooks.ini')
     create_config_file(configfile_path=configfile_path)
-    create_git_hooks(configfile_path, githooks_dir)
+    create_git_hooks(configfile_path=configfile_path, githooks_dir=githooks_dir)
     assert os.path.isfile(os.path.join(githooks_dir, 'pre-commit')) is True
     with open(os.path.join(githooks_dir, 'pre-commit'), 'r') as f:
         assert f.read() == 'githooks pre-commit'
@@ -37,7 +38,7 @@ def test_git_hook_creation_permissions(workspace_with_git):
     githooks_dir = os.path.join(workspace_with_git, '.git/hooks')
     configfile_path = os.path.join(workspace_with_git, '.githooks.ini')
     create_config_file(configfile_path=configfile_path)
-    create_git_hooks(configfile_path, githooks_dir)
+    create_git_hooks(configfile_path=configfile_path, githooks_dir=githooks_dir)
     assert os.access(os.path.join(githooks_dir, 'pre-commit'), os.X_OK) is True
 
 
@@ -45,7 +46,7 @@ def test_git_hook_creation_exit(mocker, workspace_with_git):
     """create_git_hooks helper function should exit if not valid configuration file is provided"""
     mocked_sys_exit = mocker.patch('sys.exit')
     githooks_dir = os.path.join(workspace_with_git, '.git/hooks')
-    create_git_hooks('wrong_config_file.ini', githooks_dir)
+    create_git_hooks(configfile_path='wrong_config_file.ini', githooks_dir=githooks_dir)
     mocked_sys_exit.assert_called_once_with(1)
 
 
@@ -53,5 +54,5 @@ def test_git_hook_execution_exit(mocker, workspace_with_config):
     """execute_git_hook helper function should exit with command successfully executed"""
     mocked_sys_exit = mocker.patch('sys.exit')
     configfile_path = os.path.join(workspace_with_config, '.githooks.ini')
-    execute_git_hook('pre-commit', configfile_path)
+    execute_git_hook(hook_name='pre-commit', configfile_path=configfile_path)
     mocked_sys_exit.assert_called_once_with(0)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -26,9 +26,7 @@ def test_config_file_default_values(workspace_without_git):
 def test_git_hook_creation(workspace_with_git):
     """create_git_hooks helper function should create hooks files in the git hook folder"""
     for hook_name in AVAILABLE_HOOKS:
-        assert (
-            os.path.isfile(os.path.join(workspace_with_git.hooks, hook_name)) is False
-        )
+        assert not os.path.isfile(os.path.join(workspace_with_git.hooks, hook_name))
 
     create_config_file(configfile_path=workspace_with_git.config)
     create_git_hooks(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -36,7 +36,7 @@ def test_git_hook_creation(workspace_with_git):
     )
 
     for hook_name in AVAILABLE_HOOKS:
-        assert os.path.isfile(os.path.join(workspace_with_git.hooks, hook_name)) is True
+        assert os.path.isfile(os.path.join(workspace_with_git.hooks, hook_name))
         with open(os.path.join(workspace_with_git.hooks, hook_name), "r") as f:
             assert f.read() == "githooks {}".format(hook_name)
 
@@ -65,10 +65,7 @@ def test_git_hook_creation_permissions(workspace_with_git):
         configfile_path=workspace_with_git.config, githooks_dir=workspace_with_git.hooks
     )
     for hook_name in AVAILABLE_HOOKS:
-        assert (
-            os.access(os.path.join(workspace_with_git.hooks, hook_name), os.X_OK)
-            is True
-        )
+        assert os.access(os.path.join(workspace_with_git.hooks, hook_name), os.X_OK)
 
 
 def test_git_hook_creation_exit(mocker, workspace_with_git):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,6 @@
 import os
 from configparser import ConfigParser
-from python_githooks.constants import AVAILABLE_HOOKS
+from python_githooks.constants import AVAILABLE_HOOKS, DEFAULT_COMMANDS
 from python_githooks.helpers import (
     create_config_file,
     create_git_hooks,
@@ -17,13 +17,12 @@ def test_config_file_creation(workspace_without_git):
 
 def test_config_file_default_values(workspace_without_git):
     """create_config_file helper function should create file with defaults values"""
-    default_pre_commit_command = "echo Replace this line with your own command"
     configfile_path = os.path.join(workspace_without_git, ".githooks.ini")
     create_config_file(configfile_path=configfile_path)
     config = ConfigParser()
     config.read(configfile_path)
-    assert config.sections() == list(AVAILABLE_HOOKS)
-    assert config["pre-commit"]["command"] == default_pre_commit_command
+    assert config.sections() == sorted(AVAILABLE_HOOKS)
+    assert config["pre-commit"]["command"] == DEFAULT_COMMANDS.get("pre-commit")
 
 
 def test_git_hook_creation(workspace_with_git):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -41,6 +41,23 @@ def test_git_hook_creation(workspace_with_git):
             assert f.read() == "githooks {}".format(hook_name)
 
 
+def test_git_hook_preservation(workspace_with_git):
+    """create_config_file helper function should preserve valid existing hook values"""
+    configfile_path = os.path.join(workspace_with_git, ".githooks.ini")
+    githooks_dir = os.path.join(workspace_with_git, ".git/hooks")
+    with open(os.path.join(githooks_dir, "pre-commit"), "w") as f:
+        f.write("echo successfully preserved")
+    with open(os.path.join(githooks_dir, "post-commit"), "w") as f:
+        f.write("githooks donotkeep")
+
+    create_config_file(configfile_path=configfile_path)
+    create_git_hooks(configfile_path=configfile_path, githooks_dir=githooks_dir)
+    config = ConfigParser()
+    config.read(configfile_path)
+    assert config["pre-commit"]["command"] == "echo successfully preserved"
+    assert config["post-commit"]["command"] == ""
+
+
 def test_git_hook_creation_permissions(workspace_with_git):
     """create_git_hooks helper function should create hooks files with correct permissions"""
     githooks_dir = os.path.join(workspace_with_git, ".git/hooks")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -57,3 +57,15 @@ def test_main_entry_point_githook_execution(mocker, no_sys_args, workspace_with_
         assert mocked_execute_git_hook.call_count == 1
         assert mocked_execute_git_hook.call_args[1]["hook_name"] == "pre-commit"
         mocked_sys_exit.assert_called_once_with(0)
+
+
+def test_main_entry_point_deactivation(mocker, no_sys_args, workspace_with_config):
+    """main function should execute first argument as githook"""
+    with mock_githooks_main(workspace_with_config) as mocked_githooks_main:
+        mocked_delete_git_hook = mocker.spy(mocked_githooks_main, "delete_git_hooks")
+        sys.argv.extend(["--activate", "--deactivate"])
+        main()
+        mocked_delete_git_hook.assert_called_once_with(
+            configfile_path=workspace_with_config.config,
+            githooks_dir=workspace_with_config.hooks,
+        )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,8 +8,11 @@ from python_githooks.__main__ import main
 def test_main_entry_point_exit(mocker, workspace_without_git):
     """main function should exit if ran in not valid git project"""
     python_githooks.__main__.__BASE_DIR__ = workspace_without_git
-    python_githooks.__main__.__GITHOOKS_BASE_DIR__ = os.path.join(workspace_without_git, '.git/hooks')
-    mocked_sys_exit = mocker.patch('sys.exit')
+    python_githooks.__main__.__GITHOOKS_BASE_DIR__ = os.path.join(
+        workspace_without_git, ".git/hooks"
+    )
+    mocked_sys_exit = mocker.patch("sys.exit")
+    sys.argv = sys.argv[:1]
     main()
     mocked_sys_exit.assert_called_once_with(1)
 
@@ -17,10 +20,15 @@ def test_main_entry_point_exit(mocker, workspace_without_git):
 def test_main_entry_point_config_file_creation(mocker, workspace_with_git):
     """main function should create config file if it doesn't exists"""
     python_githooks.__main__.__BASE_DIR__ = workspace_with_git
-    python_githooks.__main__.__GITHOOKS_BASE_DIR__ = os.path.join(workspace_with_git, '.git/hooks')
-    python_githooks.__main__.__GITHOOKS_CONFIGFILE_PATH__ = os.path.join(workspace_with_git, '.githooks.ini')
-    mocker.spy(python_githooks.__main__, 'create_config_file')
-    mocker.spy(python_githooks.__main__, 'create_git_hooks')
+    python_githooks.__main__.__GITHOOKS_BASE_DIR__ = os.path.join(
+        workspace_with_git, ".git/hooks"
+    )
+    python_githooks.__main__.__GITHOOKS_CONFIGFILE_PATH__ = os.path.join(
+        workspace_with_git, ".githooks.ini"
+    )
+    mocker.spy(python_githooks.__main__, "create_config_file")
+    mocker.spy(python_githooks.__main__, "create_git_hooks")
+    sys.argv = sys.argv[:1]
     main()
     assert python_githooks.__main__.create_config_file.call_count == 1
     assert python_githooks.__main__.create_git_hooks.call_count == 1
@@ -29,12 +37,16 @@ def test_main_entry_point_config_file_creation(mocker, workspace_with_git):
 def test_main_entry_point_githook_execution(mocker, workspace_with_config):
     """main function should execute first argument as githook"""
     python_githooks.__main__.__BASE_DIR__ = workspace_with_config
-    python_githooks.__main__.__GITHOOKS_BASE_DIR__ = os.path.join(workspace_with_config, '.git/hooks')
-    python_githooks.__main__.__GITHOOKS_CONFIGFILE_PATH__ = os.path.join(workspace_with_config, '.githooks.ini')
-    mocked_sys_exit = mocker.patch('sys.exit')
-    mocker.spy(python_githooks.__main__, 'execute_git_hook')
-    sys.argv = sys.argv[:1] + ['-v', 'pre-commit']
+    python_githooks.__main__.__GITHOOKS_BASE_DIR__ = os.path.join(
+        workspace_with_config, ".git/hooks"
+    )
+    python_githooks.__main__.__GITHOOKS_CONFIGFILE_PATH__ = os.path.join(
+        workspace_with_config, ".githooks.ini"
+    )
+    mocked_sys_exit = mocker.patch("sys.exit")
+    mocked_execute_git_hook = mocker.spy(python_githooks.__main__, "execute_git_hook")
+    sys.argv = sys.argv[:1] + ["--activate", "pre-commit"]
     main()
-    assert python_githooks.__main__.execute_git_hook.call_count == 1
-    assert python_githooks.__main__.execute_git_hook.call_args[1]["section"] == 'pre-commit'
+    assert mocked_execute_git_hook.call_count == 1
+    assert mocked_execute_git_hook.call_args[1]["hook_name"] == "pre-commit"
     mocked_sys_exit.assert_called_once_with(0)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,3 @@
-import os
 import sys
 
 import python_githooks
@@ -7,10 +6,8 @@ from python_githooks.__main__ import main
 
 def test_main_entry_point_exit(mocker, workspace_without_git):
     """main function should exit if ran in not valid git project"""
-    python_githooks.__main__.__BASE_DIR__ = workspace_without_git
-    python_githooks.__main__.__GITHOOKS_BASE_DIR__ = os.path.join(
-        workspace_without_git, ".git/hooks"
-    )
+    python_githooks.__main__.__BASE_DIR__ = workspace_without_git.base
+    python_githooks.__main__.__GITHOOKS_BASE_DIR__ = workspace_without_git.hooks
     mocked_sys_exit = mocker.patch("sys.exit")
     sys.argv = sys.argv[:1]
     main()
@@ -19,13 +16,9 @@ def test_main_entry_point_exit(mocker, workspace_without_git):
 
 def test_main_entry_point_config_file_creation(mocker, workspace_with_git):
     """main function should create config file if it doesn't exists"""
-    python_githooks.__main__.__BASE_DIR__ = workspace_with_git
-    python_githooks.__main__.__GITHOOKS_BASE_DIR__ = os.path.join(
-        workspace_with_git, ".git/hooks"
-    )
-    python_githooks.__main__.__GITHOOKS_CONFIGFILE_PATH__ = os.path.join(
-        workspace_with_git, ".githooks.ini"
-    )
+    python_githooks.__main__.__BASE_DIR__ = workspace_with_git.base
+    python_githooks.__main__.__GITHOOKS_BASE_DIR__ = workspace_with_git.hooks
+    python_githooks.__main__.__GITHOOKS_CONFIGFILE_PATH__ = workspace_with_git.config
     mocker.spy(python_githooks.__main__, "create_config_file")
     mocker.spy(python_githooks.__main__, "create_git_hooks")
     sys.argv = sys.argv[:1]
@@ -36,13 +29,9 @@ def test_main_entry_point_config_file_creation(mocker, workspace_with_git):
 
 def test_main_entry_point_githook_execution(mocker, workspace_with_config):
     """main function should execute first argument as githook"""
-    python_githooks.__main__.__BASE_DIR__ = workspace_with_config
-    python_githooks.__main__.__GITHOOKS_BASE_DIR__ = os.path.join(
-        workspace_with_config, ".git/hooks"
-    )
-    python_githooks.__main__.__GITHOOKS_CONFIGFILE_PATH__ = os.path.join(
-        workspace_with_config, ".githooks.ini"
-    )
+    python_githooks.__main__.__BASE_DIR__ = workspace_with_config.base
+    python_githooks.__main__.__GITHOOKS_BASE_DIR__ = workspace_with_config.hooks
+    python_githooks.__main__.__GITHOOKS_CONFIGFILE_PATH__ = workspace_with_config.config
     mocked_sys_exit = mocker.patch("sys.exit")
     mocked_execute_git_hook = mocker.spy(python_githooks.__main__, "execute_git_hook")
     sys.argv = sys.argv[:1] + ["--activate", "pre-commit"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,41 +1,59 @@
 import sys
+from contextlib import contextmanager
 
 import python_githooks
 from python_githooks.__main__ import main
 
 
-def test_main_entry_point_exit(mocker, workspace_without_git):
+@contextmanager
+def mock_properties(obj, mappings):
+    initials = {}
+    for name, value in mappings.items():
+        initials[name] = getattr(obj, name)
+        setattr(obj, name, value)
+    yield obj
+    for name, value in initials.items():
+        setattr(obj, name, value)
+
+
+def mock_githooks_main(workspace_paths):
+    mappings = {
+        "BASE_DIR": workspace_paths.base,
+        "GITHOOKS_BASE_DIR": workspace_paths.hooks,
+        "GITHOOKS_CONFIGFILE_PATH": workspace_paths.config,
+    }
+    return mock_properties(
+        python_githooks.__main__,
+        {"__{}__".format(name): value for name, value in mappings.items()},
+    )
+
+
+def test_main_entry_point_exit(mocker, no_sys_args, workspace_without_git):
     """main function should exit if ran in not valid git project"""
-    python_githooks.__main__.__BASE_DIR__ = workspace_without_git.base
-    python_githooks.__main__.__GITHOOKS_BASE_DIR__ = workspace_without_git.hooks
-    mocked_sys_exit = mocker.patch("sys.exit")
-    sys.argv = sys.argv[:1]
-    main()
-    mocked_sys_exit.assert_called_once_with(1)
+    with mock_githooks_main(workspace_without_git):
+        mocked_sys_exit = mocker.patch("sys.exit")
+        main()
+        mocked_sys_exit.assert_called_once_with(1)
 
 
-def test_main_entry_point_config_file_creation(mocker, workspace_with_git):
+def test_main_entry_point_config_file_creation(mocker, no_sys_args, workspace_with_git):
     """main function should create config file if it doesn't exists"""
-    python_githooks.__main__.__BASE_DIR__ = workspace_with_git.base
-    python_githooks.__main__.__GITHOOKS_BASE_DIR__ = workspace_with_git.hooks
-    python_githooks.__main__.__GITHOOKS_CONFIGFILE_PATH__ = workspace_with_git.config
-    mocker.spy(python_githooks.__main__, "create_config_file")
-    mocker.spy(python_githooks.__main__, "create_git_hooks")
-    sys.argv = sys.argv[:1]
-    main()
-    assert python_githooks.__main__.create_config_file.call_count == 1
-    assert python_githooks.__main__.create_git_hooks.call_count == 1
+    with mock_githooks_main(workspace_with_git) as mocked_githooks_main:
+        mocked_create_config = mocker.spy(mocked_githooks_main, "create_config_file")
+        mocked_create_githooks = mocker.spy(mocked_githooks_main, "create_git_hooks")
+        sys.argv = sys.argv[:1]
+        main()
+        assert mocked_create_config.call_count == 1
+        assert mocked_create_githooks.call_count == 1
 
 
-def test_main_entry_point_githook_execution(mocker, workspace_with_config):
+def test_main_entry_point_githook_execution(mocker, no_sys_args, workspace_with_config):
     """main function should execute first argument as githook"""
-    python_githooks.__main__.__BASE_DIR__ = workspace_with_config.base
-    python_githooks.__main__.__GITHOOKS_BASE_DIR__ = workspace_with_config.hooks
-    python_githooks.__main__.__GITHOOKS_CONFIGFILE_PATH__ = workspace_with_config.config
-    mocked_sys_exit = mocker.patch("sys.exit")
-    mocked_execute_git_hook = mocker.spy(python_githooks.__main__, "execute_git_hook")
-    sys.argv = sys.argv[:1] + ["--activate", "pre-commit"]
-    main()
-    assert mocked_execute_git_hook.call_count == 1
-    assert mocked_execute_git_hook.call_args[1]["hook_name"] == "pre-commit"
-    mocked_sys_exit.assert_called_once_with(0)
+    with mock_githooks_main(workspace_with_config) as mocked_githooks_main:
+        mocked_sys_exit = mocker.patch("sys.exit")
+        mocked_execute_git_hook = mocker.spy(mocked_githooks_main, "execute_git_hook")
+        sys.argv.extend(["--activate", "pre-commit"])
+        main()
+        assert mocked_execute_git_hook.call_count == 1
+        assert mocked_execute_git_hook.call_args[1]["hook_name"] == "pre-commit"
+        mocked_sys_exit.assert_called_once_with(0)


### PR DESCRIPTION
Shims all git hooks on activation and unshims on `--deactivate`.

Does not require user to rerun `githooks` when `.githooks.ini` file changes as commands are read from the config in real time.